### PR TITLE
Remove member representatives after initial phase

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -14,10 +14,12 @@ The OpenRail Foundation's Technical Committee (TC) is responsible for selecting 
 
 ## Composition of the TC
 
-The TC is composed of:
+The TC is initially composed of:
 
 * One representative of each Platinum member. The representative of the Platinum member to the OpenRail Foundation designates the representative in the TC. The designation can be changed at any time.
 * One representative of each project hosted by the OpenRail Foundation. The representative has to be one of the maintainers of the project. If there are multiple maintainers of a project, the project designates who of the maintainers represents the project in the TC. The designation can be changed at any time.
+
+The participation of designated representative of Platinum members is meant to start the work of the TC, when no or only few projects are in the Foundation. When there are more than seven projects in the foundation, the TC will only consist of representatives by the projects. Designated representatives of the Platinum members will leave the TC latest three months after the number of projects reached the threshold.
 
 ## Chair of the TC
 


### PR DESCRIPTION
This change suggest a two phased approach to the composition of the TC.

In the initial phase it consists of representatives of the Foundation members plus representatives of the project. This is meant to staff the TC committee when there are no or only few projects and consequently no or few people in the TC.

When there are enough projects to staff the TC, the representatives of the Foundation members leave the TC, and it is only composed of the representatives of the projects.

Pro for removing Foundation member representatives: It's a more representative structure of the projects. Platinum members have less influence on the TC purely based on membership in the Foundation.

Contra against removing Foundation member representatives: Project representatives are specialists which are busy with their own projects and might not be interested in other projects. Member representatives will likely tend to be more generalists, so that they are more likely to engage in overall cross-project questions.