### PR TITLE
Add draft for questionnaire for new projects

### DIFF
--- a/new-project-questionnaire.md
+++ b/new-project-questionnaire.md
@@ -1,0 +1,28 @@
+# Questionnaire for projects intending to join the OpenRail Association
+
+As a project intending to join the OpenRail Association, please fill out this questionnaire and send it to the Technical Committee. See the [incubation process](incubation_process.md) for details about criteria and requirements for new projects and how it works to get new projects into the association.
+
+## Questions
+
+* What is the project's name?
+* Describe the project. What does the project do, why is it valuable, where does it come from?
+* Who are the maintainers of the project (these will be the primary contacts for the OpenRail Association)?
+* Which organizations are sponsoring/contributing to the project?
+* Where is the code hosted?
+* What is the project's main license?
+* What other licenses does the project use, e.g. for included 3rd party code?
+* Are any trademarks associated with the project?
+* Does the project have a web site? Where is it?
+* What are the communication channels the project uses (such as mailing lists, Slack, IRC, etc.)?
+* What is the project's leadership team and decision-making process?
+* How is development of the project planned and organized? Is this transparent to the public?
+* What is the project's roadmap?
+* What other organizations in the world should be interested in this project?
+* Why would this project be a good candidate for inclusion in the OpenRail Association?
+* What is the project's plan for growing in maturity if accepted within the OpenRail Association?
+
+## Concluding statements
+
+By sending this questionnaire you confirm that the project will adhere to the [code of conduct](CODE_OF_CONDUCT.md) of the OpenRail Association.
+
+By sending this questionnaire you confirm that the project intends to be incubated in the OpenRail Association and plans to meet the maturity criteria set out by the OpenRail Association for incubated projects.


### PR DESCRIPTION
This is a draft for the questionnaire new projects intending to join the OpenRail Association have to fill out. It's meant to create transparency about the project and how it works, so it can be assessed for inclusion in OpenRail. It also provides a base to review further improvements in maturity on the project life cycle within OpenRail.
