### PR TITLE
Refine draft for incubation process

### DIFF
--- a/incubation_process.md
+++ b/incubation_process.md
@@ -49,7 +49,6 @@ The barrier for entering the Incubation stage is intended to be high, so there i
 
 *Examples from CNCF incubation process, to be adopted*
 
-* Apply to move to Incubation using the questionnaire (to be done).
 * Document that it is being used successfully in production by at least three independent adopters which, in the TOC’s judgement, are of adequate quality and scope.
 * Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
 * Demonstrate a substantial ongoing flow of commits and merged contributions.
@@ -57,6 +56,13 @@ The barrier for entering the Incubation stage is intended to be high, so there i
 * A clear versioning scheme.
 * Specifications must have at least one public reference implementation.
 * Project explains the business roadmap.
+
+### Process
+
+1. Apply to move to Incubation using the questionnaire (to be done).
+2. The Technical Committee evaluates the application and works with the project to address any open issues.
+3. On a positive evaluation the Technical Committee decides to accept the project as an Incubation project.
+4. Sandbox projects can use the badge "OpenRail project (Incubation)" (to be created).
 
 ## Stage 3: Graduated
 
@@ -75,6 +81,13 @@ The Graduated stage is for projects which have reached a level of hight maturity
 * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
 * Please include a short one-page narrative based off the Graduation template, no more than 500 words.
 
+### Process
+
+1. Apply to move to Graduation using the questionnaire (to be done).
+2. The Technical Committee evaluates the application and works with the project to address any open issues.
+3. On a positive evaluation the Technical Committee decides to accept the project as a Graduation project.
+4. Graduation projects can use the badge "OpenRail project (Graduation)" (to be created).
+
 ## Stage 4: Retired
 
 Project that aren't developed anymore or that have been replaced by another project are moved to the Retired stage.
@@ -83,6 +96,14 @@ Project that aren't developed anymore or that have been replaced by another proj
 
 * Project has no active maintainers
 * Development activity has slowed significantly
+
+### Process
+
+1. A project requests the project to be moved to the Retired stage or the Technical Committee finds that an existing project is not active anymore.
+2. The project is noticed that it is about to be moved to the Retired stage.
+3. The project can object and provide evidence that it still is active.
+4. If there is no evidence that the project is still active the Technical Committee decides to move the project to the Retired stage.
+5. The project is clearly marked as Retired in its GitHub repository and any other relevant locations.
 
 ## References
 

--- a/incubation_process.md
+++ b/incubation_process.md
@@ -49,7 +49,6 @@ The barrier for entering the Incubation stage is intended to be high, so there i
 
 *Examples from CNCF incubation process, to be adopted*
 
-* Document that it is being used successfully in production by at least three independent adopters which, in the TOC’s judgement, are of adequate quality and scope.
 * Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
 * Demonstrate a substantial ongoing flow of commits and merged contributions.
 * Since these metrics can vary significantly depending on the type, scope and size of a project, the TOC has final judgement over the level of activity that is adequate to meet these criteria
@@ -72,7 +71,7 @@ The Graduated stage is for projects which have reached a level of hight maturity
 
 *Examples from CNCF incubation process, to be adopted*
 
-* Apply to move to Graduated using the questionnaire (to be done).
+* Document that it is being used successfully in production by at least three independent adopters which, in the TC’s judgement, are of adequate quality and scope.
 * Have committers from at least two organizations.
 * Have achieved and maintained a OpenSSF Best Practices Badge.
 * Have completed an independent and third party security audit with results published of similar scope and quality as this example which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.

--- a/incubation_process.md
+++ b/incubation_process.md
@@ -1,66 +1,64 @@
-# Incubation process
+# OpenRail Incubation process
 
 *This is a draft*
 
-## Funnel
+This document describes the incubation process for projects in the OpenRail Association. This includes how a project can join OpenRail as well as how a project can move to subsequent stages of maturity.
 
-The project is candidate. The Association proceeds to compliance, business and technical evaluation.
-
-### Compliance evaluation:
-
--	The project provides all the documents (IP, CoC, License, …)
--	The TC check that the project is compliant with the ORF rules.
-
-### Business evaluation
-
--	The project describes the need it fulfills, and which strategic themes are concerned by the project.
--	The project explains the business roadmap.
-
-### Technical evaluation
-
--	The project describes the release plan.
--	The project describes the version(s):
-  - Is there a community version working on open data?
-  - Is there an enterprise version?
-  - …
--	The project describes all the stack.
--	The project describes the architecture of the software.
--	The project describes its governance
-
-## Stages
-
-Projects can be in four stages which are reflecting the maturity of the project and the rate of adoption in the OpenRail community (Sandbox, Incubation, Graduated, Retired). For each stage the project has to fulfill a set of criteria. Projects can propose to be moved from one stage to another. The TC will evaluate the proposal and decide if the project can move to the next stage.
+Projects can be in four stages which are reflecting the maturity of the project and the level of adoption in the OpenRail community (Sandbox, Incubation, Graduated, Retired). For each stage the project has to fulfill a set of criteria. Projects can propose to be moved from one stage to the next. The TC will evaluate the proposal and decide if the project can move to the next stage.
 
 ![Project lifecycle](images/incubation-stages.svg)
 
-*The stages and the process are inspired by the [CNCF project lifecycle process](https://github.com/cncf/toc/blob/main/process/README.md)*
+The criteria for entering each stage cover the compliance, business, and technical evaluation of the project. The evaluation has to be done for each version of the project. A community version could be accepted and not the enterprise version.
 
-## Sandbox
+The criteria for each stage are listed in the subsequent sections along with the process how projects are accepted into the corresponding stage.
+
+## Stage 0: Candidate
+
+Projects which intend to join the OpenRail Association are considered candidates. Candidates are not yet OpenRail projects. They are evaluated by the Technical Committee on request of the project to become part of the OpenRail Association. Candidates need to at least fulfill the criteria for the Sandbox stage to be accepted into the OpenRail Association.
+
+## Stage 1: Sandbox
 
 The Sandbox stage is the initial stage for projects being hosted by the OpenRail Association. Sandbox projects meet the minimal requirements necessary for being considered to be part of the OpenRail Association. The Sandbox stage is meant for projects that are in an early phase and are being prepared for meeting the full criteria of the Incubation stage.
 
+The barrier for entering the Sandbox stage is intended to be low, so that it's easy for projects to become part of the OpenRail Association and the work necessary for moving to the next stage can be done within the Association.
+
 ### Criteria
 
-* Apply to join the Sandbox using the [New Project Questionnaire](new_project_questionnaire.md)
+* Describe project
+* Name maintainers of the project
 * Adopt the OpenRail Association Code of Conduct
 * Adhere to OpenRail Association IP Policy
 
-## Incubation
+### Process
 
-The Incubation stage is for projects that have reached a level of maturity that indicates they are ready to be used by end users. Incubation projects meet the main criteria of the OpenRail Association which make sure that the project is governed openly.
+1. The project applies to join the Sandbox using the [New Project Questionnaire](new_project_questionnaire.md).
+2. The Technical Committee evaluates the application and works with the project to address any open issues.
+3. On a positive evaluation the Technical Committee prepares the decision to accept the project as an OpenRail Association project.
+4. According to the statutes of the OpenRail Association Article 22 the OpenRail board finally decides about the acceptance of the project based on the decision prepared by the Technical Committee.
+5. The project is accepted into the OpenRail Association as Sandbox project and their code is moved to the [GitHub organization of the OpenRail Association](https://github.com/OpenRailAssociation).
+6. The project is listed on the [OpenRail Association web site](https://openrailassociation.org).
+7. Sandbox projects can use the badge "OpenRail project (Sandbox)" (to be created).
+
+## Stage 2: Incubation
+
+The Incubation stage is for projects that have reached a level of maturity that indicates they are ready to be used by end users. Incubation projects meet the main criteria of the OpenRail Association which make sure that the project is governed openly. Open governance means that decisions are taken in a transparent way and there is a path to become committer and maintainer based on the merits of contributions.
+
+The barrier for entering the Incubation stage is intended to be high, so there is a high level of quality for projects which have reached this stage.
 
 ### Criteria
 
 *Examples from CNCF incubation process, to be adopted*
 
+* Apply to move to Incubation using the questionnaire (to be done).
 * Document that it is being used successfully in production by at least three independent adopters which, in the TOC’s judgement, are of adequate quality and scope.
 * Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
 * Demonstrate a substantial ongoing flow of commits and merged contributions.
 * Since these metrics can vary significantly depending on the type, scope and size of a project, the TOC has final judgement over the level of activity that is adequate to meet these criteria
 * A clear versioning scheme.
 * Specifications must have at least one public reference implementation.
+* Project explains the business roadmap.
 
-## Graduated
+## Stage 3: Graduated
 
 The Graduated stage is for projects which have reached a level of hight maturity and adoption. They are the flagship projects of the OpenRail Association.
 
@@ -68,6 +66,7 @@ The Graduated stage is for projects which have reached a level of hight maturity
 
 *Examples from CNCF incubation process, to be adopted*
 
+* Apply to move to Graduated using the questionnaire (to be done).
 * Have committers from at least two organizations.
 * Have achieved and maintained a OpenSSF Best Practices Badge.
 * Have completed an independent and third party security audit with results published of similar scope and quality as this example which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
@@ -76,7 +75,7 @@ The Graduated stage is for projects which have reached a level of hight maturity
 * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
 * Please include a short one-page narrative based off the Graduation template, no more than 500 words.
 
-## Retired
+## Stage 4: Retired
 
 Project that aren't developed anymore or that have been replaced by another project are moved to the Retired stage.
 
@@ -85,25 +84,6 @@ Project that aren't developed anymore or that have been replaced by another proj
 * Project has no active maintainers
 * Development activity has slowed significantly
 
-## TC evaluation and advice to the Board of Directors
+## References
 
-The evaluation has to be done for each version of the project.
-A community version could be accepted and not the enterprise version.
-
-## The Board of Director validates the candidate as a project hosted by the OpenRail Association
-
-According to the statutes of the OpenRail Association Article 22 the OpenRail board finally decides about the acceptance of the project based on the decision prepared by the Technical Committee.
-
-## Appendix
-
-### Template for project proposal for Sandbox stage
-
-See [New Project Questionnaire](new_project_questionnaire.md)
-
-### Template for project proposal for Incubation stage
-
-* Project description
-  * Compliance
-  * Technical
-  * Business
-* List of criteria and how the project fulfill them
+The stages and the process are inspired by the [CNCF project lifecycle process](https://github.com/cncf/toc/blob/main/process/README.md) and the [LF Energy technical project lifecycle](https://wiki.lfenergy.org/display/HOME/Technical+Project+Lifecycle).


### PR DESCRIPTION
This pull request refines the draft for the incubation process so it has a clear description of each stage of the project lifecycle and the corresponding process how to get accepted into each stage. It also consolidates the information which was spread out in several sections into the common structure for each stage. The general information is put together in the introducing paragraphs.

From my point of view the process is ready to be used for the first stage, i.e. accepting new projects.

For later stages we need to review the criteria and adapt them if needed.

We also might want to discuss the names of the stages to have something which is clear in our context. But this won't change the criteria or the process, so it should not prevent us from starting project incubation.

We had discussed adding an additional "Early adoption" stage as a more light-weight version of the "Graduation" stage, but I think we shoud keep it simple for now and address this questions when the need arises. The criteria for adoption in production by multiple parties I moved from the Incubation stage to the Graduation stage.

We still need to update the diagram to reflect that a project can be moved to Retired from all stages, not only from the Retired stage, but this is a detail, which we also can add later.