### PR TITLE
Document governance of this repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+This Project welcomes contributions, suggestions, and feedback. All contributions, suggestions, and feedback you submitted are accepted under the license [CC BY 4.0](./LICENSE). You represent that if you do not own copyright in the code that you have the authority to submit it under the [Project's license](./LICENSE). All feedback, suggestions, or contributions are not confidential.
+
+This repository is the home of the official documents maintained by the technical committee of the OpenRail Association. For minor changes such as typo fixes please just open a pull request. For any substantial changes of the content please get in contact first, for example by opening an issue.
+
+---
+Based on [GitHub's Minimum Viable Governance (MVG)](https://github.com/github/MVG). Licensed under the [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,8 @@ See the [Charter of the Technical Committee](charter.md) for the details of its 
 | --- | --- |
 | Cornelius Schumacher | DB Systel GmbH |
 | Max Mehl | DB Systel GmbH |
+| Loic Hamelin | SNCF Reseau |
+| Peter Keller | SBB |
 
 ---
 Based on [GitHub's Minimum Viable Governance (MVG)](https://github.com/github/MVG). Licensed under the [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# Maintainers
+
+This document lists the Maintainers of this repository. Maintainers are appointed by the Technical Committee of the OpenRail Association. The Maintainers act as technical maintainers of the repo, reviewing and merging pull request, and doing other administrative work. The content is subject to approval by the Technical Committee.
+
+See the [Charter of the Technical Committee](charter.md) for the details of its governance.
+
+| **NAME** | **Organization** |
+| --- | --- |
+| Cornelius Schumacher | DB Systel GmbH |
+| Max Mehl | DB Systel GmbH |
+
+---
+Based on [GitHub's Minimum Viable Governance (MVG)](https://github.com/github/MVG). Licensed under the [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Document the governance of this repository based on the project governance templates of the OpenRail Association.

The technical-committee repo is a bit of a special case here, as it's not a software project, but the official repo for documents maintained by the technical committee. This includes templates to be used by all the projects as well as the documents related to the incubation process. This all is ultimately governed by the charter of the technical commiittee.