### PR TITLE
fix(project-templates): fix wrong links to CODE_OF_CONDUCT.md

### DIFF
--- a/project-templates/GOVERNANCE.md
+++ b/project-templates/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Governance Policy
 
-This document provides the governance policy for the Project. Maintainers agree to this policy and to abide by all Project policies, including the [code of conduct](./CODE-OF-CONDUCT.md) by adding their name to the [`MAINTAINERS.md` file](./MAINTAINERS.md).
+This document provides the governance policy for the Project. Maintainers agree to this policy and to abide by all Project policies, including the [code of conduct](./CODE_OF_CONDUCT.md) by adding their name to the [`MAINTAINERS.md` file](./MAINTAINERS.md).
 
 ## 1. Roles.
 

--- a/project-templates/MAINTAINERS.md
+++ b/project-templates/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Maintainers
 
-This document lists the Maintainers of the Project. Maintainers may be added once approved by the existing maintainers as described in the [Governance document](./GOVERNANCE.md). By adding your name to this list you are agreeing to abide by the Project governance documents and to abide by all of the Organization's policies, including the [code of conduct](./CODE-OF-CONDUCT.md). If you are participating because of your affiliation with another organization (designated below), you represent that you have the authority to bind that organization to these policies.
+This document lists the Maintainers of the Project. Maintainers may be added once approved by the existing maintainers as described in the [Governance document](./GOVERNANCE.md). By adding your name to this list you are agreeing to abide by the Project governance documents and to abide by all of the Organization's policies, including the [code of conduct](./CODE_OF_CONDUCT.md). If you are participating because of your affiliation with another organization (designated below), you represent that you have the authority to bind that organization to these policies.
 
 | **NAME** | **Organization** |
 | --- | --- |


### PR DESCRIPTION
While adopting the governance and maintainers files for one of our project I realized that the links to the code of conduct file are wrong.