### PR TITLE
Update process on creating additional repositories

### DIFF
--- a/project-handbook/github-management.md
+++ b/project-handbook/github-management.md
@@ -14,7 +14,7 @@ The first repository will be set up as part of the onboarding as soon as the pro
 
 On the [project list](https://github.com/OpenRailAssociation/technical-committee/blob/main/projects.md) we list all repositories which belong to each OpenRail project. If you need an additional repository, create a pull request there with the name of the new repository and add any details in the text of the pull request. An owner of the organization will then work with you to set it up according to your needs. Once the setup is complete the pull request will be merged, so that the repo also shows up in the official project list.
 
-Note that all repositories in OpenRail must be public and only contain material licensed under an Open Source license. If you need a space for private/sensible information, e.g. for deployment, you must do that elsewhere. However, all information in order to run/deploy your project must in some way be transparent to the public.
+Note that all repositories in OpenRail must be public and only contain material licensed under an Open Source license. If you need a space for private/sensible information, e.g., for deployment, you must do that elsewhere. However, all information in order to run/deploy your project must in some way be transparent to the public.
 
 ## Members, teams, and permissions
 

--- a/project-handbook/github-management.md
+++ b/project-handbook/github-management.md
@@ -8,7 +8,7 @@ Naming is hard. Within OpenRail, all elements such as repositories must be prepe
 
 ## Repositories
 
-Only owners of the OpenRail organisation can create new repositories. This is to prevent clutter and unclear permissions.
+Only owners of the OpenRail organization can create new repositories. This is to prevent clutter and unclear permissions.
 
 The first repository will be set up as part of the onboarding as soon as the project has been accepted by the OpenRail Association in the [incubation process](https://github.com/OpenRailAssociation/technical-committee/blob/main/incubation_process.md).
 

--- a/project-handbook/github-management.md
+++ b/project-handbook/github-management.md
@@ -10,9 +10,9 @@ Naming is hard. Within OpenRail, all elements such as repositories must be prepe
 
 Only owners of the OpenRail organisation can create new repositories. This is to prevent clutter and unclear permissions.
 
-Please contact the Technical Committee (technical-committee@openrailassociation.org) if you need an additional repository, with information about its name and potentially unusual settings.
+The first repository will be set up as part of the onboarding as soon as the project has been accepted by the OpenRail Association in the [incubation process](https://github.com/OpenRailAssociation/technical-committee/blob/main/incubation_process.md).
 
-Once the repository is set up, please create a pull request for the [project list](https://github.com/OpenRailAssociation/technical-committee/blob/main/projects.md) and add the new repository there.
+On the [project list](https://github.com/OpenRailAssociation/technical-committee/blob/main/projects.md) we list all repositories which belong to each OpenRail project. If you need an additional repository, create a pull request there with the name of the new repository and add any details in the text of the pull request. An owner of the organization will then work with you to set it up according to your needs. Once the setup is complete the pull request will be merged, so that the repo also shows up in the official project list.
 
 Note that all repositories in OpenRail must be public and only contain material licensed under an Open Source license. If you need a space for private/sensible information, e.g. for deployment, you must do that elsewhere. However, all information in order to run/deploy your project must in some way be transparent to the public.
 

--- a/project-handbook/github-management.md
+++ b/project-handbook/github-management.md
@@ -10,7 +10,7 @@ Naming is hard. Within OpenRail, all elements such as repositories must be prepe
 
 Only owners of the OpenRail organization can create new repositories. This is to prevent clutter and unclear permissions.
 
-The first repository will be set up as part of the onboarding as soon as the project has been accepted by the OpenRail Association in the [incubation process](https://github.com/OpenRailAssociation/technical-committee/blob/main/incubation_process.md).
+The first repository will be set up as part of the onboarding as soon as the project has been accepted by the OpenRail Association in the [incubation process](https://github.com/OpenRailAssociation/technical-committee/blob/main/incubation-process.md).
 
 On the [project list](https://github.com/OpenRailAssociation/technical-committee/blob/main/projects.md) we list all repositories which belong to each OpenRail project. If you need an additional repository, create a pull request there with the name of the new repository and add any details in the text of the pull request. An owner of the organization will then work with you to set it up according to your needs. Once the setup is complete the pull request will be merged, so that the repo also shows up in the official project list.
 


### PR DESCRIPTION
We can now use the pull request for listing the repo on the project page as starting point for repository creation.