### PR TITLE
Document REUSE requirements

### DIFF
--- a/incubation-process.md
+++ b/incubation-process.md
@@ -56,7 +56,7 @@ The barrier for entering the Incubation stage is intended to be high, so there i
 * **The project has implemented an open governance process so that participation in the project becomes possible.** It is documented how decisions are taken in the project and how people can become committers and maintainers.
 * **There is a public business roadmap so that there is transparency about what drives the project.**
 * **The project's software is used in production so that it is demonstrated that the software is ready for serious use.** It is sufficient if this is only the organization developing the project.
-* **There is clarity about the licensing of the project so that it can be safely used in a compliant way.** To achieve that the project is [REUSE](https://reuse.software) compliant and there is an automatic check which runs the REUSE linter. Indicating copyright and license information in headers in each file is the preferred solution but to declare this information with the REUSE toml file can be a valid solution as well.
+* **There is clarity about the licensing of the project so that it can be safely used in a compliant way.** To achieve that the project is [REUSE](https://reuse.software) compliant and there is an automatic check which runs the REUSE linter. This detailed requirements and process are documented [here](project-handbook/reuse.md).
 * **The project requires the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) so that there is clarity about the provenance of contributed code.** The presence of the DCO information is automatically checked so that it is made sure that it is present in all commits.
 
 ### Process

--- a/incubation-process.md
+++ b/incubation-process.md
@@ -56,7 +56,7 @@ The barrier for entering the Incubation stage is intended to be high, so there i
 * **The project has implemented an open governance process so that participation in the project becomes possible.** It is documented how decisions are taken in the project and how people can become committers and maintainers.
 * **There is a public business roadmap so that there is transparency about what drives the project.**
 * **The project's software is used in production so that it is demonstrated that the software is ready for serious use.** It is sufficient if this is only the organization developing the project.
-* **There is clarity about the licensing of the project so that it can be safely used in a compliant way.** To achieve that the project is [REUSE](https://reuse.software) compliant and there is an automatic check which runs the REUSE linter. This detailed requirements and process are documented [here](project-handbook/reuse.md).
+* **There is clarity about the licensing of the project so that it can be safely used in a compliant way.** To achieve that the project is [REUSE](https://reuse.software) compliant and there is an automatic check which runs the REUSE linter. These detailed requirements and processes are documented [here](project-handbook/reuse.md).
 * **The project requires the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) so that there is clarity about the provenance of contributed code.** The presence of the DCO information is automatically checked so that it is made sure that it is present in all commits.
 
 ### Process

--- a/project-handbook/reuse.md
+++ b/project-handbook/reuse.md
@@ -29,7 +29,7 @@ When thinking about licensing and copyright of all your files, tricky questions 
 
 ### Annotating all files
 
-Once all these questions have been answered, the must be put into practice by adopting the REUSE standard for all your files. Ideally, each file will be annotated directly, so equipped with a comment header containing licensing and copyright information. Only if this isn't possible or not feasible (e.g. for binary or test files), one of the alternatives REUSE offers shall be chosen.
+Once all these questions have been answered, they must be put into practice by adopting the REUSE standard for all your files. Ideally, each file will be annotated directly, so equipped with a comment header containing licensing and copyright information. Only if this isn't possible or not feasible (e.g., for binary or test files), one of the alternatives REUSE offers shall be chosen.
 
 While the required information for REUSE compliance may be put manually into all files, it is strongly advised to make use of e.g. the [REUSE helper tool](https://github.com/fsfe/reuse-tool) that semi-automates many steps. However, manual checks and careful thoughts are mandatory, as described above.
 

--- a/project-handbook/reuse.md
+++ b/project-handbook/reuse.md
@@ -24,7 +24,7 @@ When thinking about licensing and copyright of all your files, tricky questions 
 
 * Are all files licensed the same way, or have files been copied from other projects under different licenses and copyrights?
 * Who owns the copyright of all the files? Just one organization, or were there contractors or external companies who acted under their own copyright?
-* Are there files that are not be licensed under the "main" license, e.g. icons, fonts, graphics, pictures?
+* Are there files that are not licensed under the "main" license, e.g., icons, fonts, graphics, pictures?
 * Are there trademarks or additional restrictions on parts of the projects, e.g. logos?
 
 ### Annotating all files

--- a/project-handbook/reuse.md
+++ b/project-handbook/reuse.md
@@ -1,8 +1,8 @@
 # Adopt REUSE to ensure licensing transparency
 
-OpenRail projects are supposed to be safely used in a compliant way. This is why from Incubation Stage 2 onwards, projects shall adopt the [REUSE](https://reuse.software/) best practices for licensing and copyright information.
+OpenRail projects are supposed to enable users to easily and safely comply with licensing requirements. Starting from Incubation Stage 2, projects are required to adopt [REUSE](https://reuse.software/) best practices for licensing and copyright information.
 
-The fundamental idea is that for all files within a project there is unambiguous information about their license and copyright. REUSE consists of a standard and various tools and services that help with reaching and ensuring this clarity.
+REUSE ensures that for every file in a project there is unambiguous information about their license and copyright. It provides a clear standard, along with tools and services, to help with achieving and maintaining this clarity.
 
 This document helps with the adoption by providing links to relevant material and making recommendations for OpenRail projects.
 
@@ -29,7 +29,7 @@ When thinking about licensing and copyright of all your files, tricky questions 
 
 ### Annotating all files
 
-Once all these questions have been answered, they must be put into practice by adopting the REUSE standard for all your files. Ideally, each file will be annotated directly, so equipped with a comment header containing licensing and copyright information. Only if this isn't possible or not feasible (e.g., for binary or test files), one of the alternatives REUSE offers shall be chosen.
+Once all these questions have been answered, they must be put into practice by documenting copyright and licensing information following the REUSE standard for all your files. Ideally, each file will be annotated directly, so equipped with a comment header containing licensing and copyright information. This gives the maximum clarity. If this isn't possible or not feasible (e.g., for binary or test files), one of the alternatives REUSE offers shall be chosen.
 
 While the required information for REUSE compliance may be put manually into all files, it is strongly advised to make use of e.g. the [REUSE helper tool](https://github.com/fsfe/reuse-tool) that semi-automates many steps. However, manual checks and careful thoughts are mandatory, as described above.
 

--- a/project-handbook/reuse.md
+++ b/project-handbook/reuse.md
@@ -25,7 +25,6 @@ When thinking about licensing and copyright of all your files, tricky questions 
 * Are all files licensed the same way, or have files been copied from other projects under different licenses and copyrights?
 * Who owns the copyright of all the files? Just one organization, or were there contractors or external companies who acted under their own copyright?
 * Are there files that are not licensed under the "main" license, e.g., icons, fonts, graphics, pictures?
-* Are there trademarks or additional restrictions on parts of the projects, e.g. logos?
 
 ### Annotating all files
 
@@ -39,3 +38,7 @@ We require two additional steps to ensure that the best practices will be kept:
 
 1. Integrate a REUSE check into your CI, to ensure that new files without proper licensing/copyright annotation issue a warning. Possibilities are explained [here](https://reuse.software/dev/), e.g. via a GitHub action.
 2. Register the project with the [REUSE API](https://api.reuse.software/) and put the resulting badge into your `README` file. This will demonstrate the adoption of this standard and therefore the re-usability to potential users and contributors.
+
+## Trademarks and further restrictions
+
+There may be further legal restrictions and rights you need to consider, for example trademarks and usage restrictions on logos and fonts. REUSE only covers licenses and copyrights. Therefore, you should communicate such additional legal information in the `README` file. Please make sure to be transparent and helpful to potential users and contributors how they can use or modify these special parts.

--- a/project-handbook/reuse.md
+++ b/project-handbook/reuse.md
@@ -1,0 +1,41 @@
+# Adopt REUSE to ensure licensing transparency
+
+OpenRail projects are supposed to be safely used in a compliant way. This is why from Incubation Stage 2 onwards, projects shall adopt the [REUSE](https://reuse.software/) best practices for licensing and copyright information.
+
+The fundamental idea is that for all files within a project there is unambiguous information about their license and copyright. REUSE consists of a standard and various tools and services that help with reaching and ensuring this clarity.
+
+This document helps with the adoption by providing links to relevant material and making recommendations for OpenRail projects.
+
+## Resources for understanding REUSE
+
+Instead of duplicating guides, we refer to helpful material that already exists and is maintained by REUSE:
+
+* [Tutorial](https://reuse.software/tutorial/) on how to become REUSE compliant: make a repository REUSE compliant in simple steps, without delving into details and edge cases.
+* [FAQ](https://reuse.software/faq/) on general questions but also how to deal with edgier cases in your project.
+* [Tools and scripts](https://reuse.software/dev/) specifically for developers, such as the helper tool, API, pre-commit hooks, and CI checks
+
+## Recommended process for OpenRail projects
+
+For Incubation Stage 2, we require projects to be fully REUSE compliant. This is measured by whether the `reuse lint` command exits successfully, but requires that the projects carefully check the licenses and copyright of all their files.
+
+### Analyse your codebase
+
+When thinking about licensing and copyright of all your files, tricky questions may arise:
+
+* Are all files licensed the same way, or have files been copied from other projects under different licenses and copyrights?
+* Who owns the copyright of all the files? Just one organization, or were there contractors or external companies who acted under their own copyright?
+* Are there files that are not be licensed under the "main" license, e.g. icons, fonts, graphics, pictures?
+* Are there trademarks or additional restrictions on parts of the projects, e.g. logos?
+
+### Annotating all files
+
+Once all these questions have been answered, the must be put into practice by adopting the REUSE standard for all your files. Ideally, each file will be annotated directly, so equipped with a comment header containing licensing and copyright information. Only if this isn't possible or not feasible (e.g. for binary or test files), one of the alternatives REUSE offers shall be chosen.
+
+While the required information for REUSE compliance may be put manually into all files, it is strongly advised to make use of e.g. the [REUSE helper tool](https://github.com/fsfe/reuse-tool) that semi-automates many steps. However, manual checks and careful thoughts are mandatory, as described above.
+
+### Ensuring and communicating REUSE adoption
+
+We require two additional steps to ensure that the best practices will be kept:
+
+1. Integrate a REUSE check into your CI, to ensure that new files without proper licensing/copyright annotation issue a warning. Possibilities are explained [here](https://reuse.software/dev/), e.g. via a GitHub action.
+2. Register the project with the [REUSE API](https://api.reuse.software/) and put the resulting badge into your `README` file. This will demonstrate the adoption of this standard and therefore the re-usability to potential users and contributors.

--- a/project-proposals/stage-2/stage-2-questionnaire.md
+++ b/project-proposals/stage-2/stage-2-questionnaire.md
@@ -53,11 +53,11 @@
 
 ### Is the project REUSE compliant?
 
-*Does the project include licensing information according to the [REUSE standard](https://reuse.software)? Please provide the link to the README where the REUSE badge is shown.*
+*Does the project include licensing information according to the [REUSE standard](https://reuse.software)? Did you register your project with the REUSE API, and set up CI checks? Are contributors informed about this in your CONTRIBUTING.md? Please provide the link to the README where the REUSE badge is shown, the CI workflow for REUSE checks, as well as your CONTRIBUTING.md where the REUSE requirement is mentioned.*
 
 ### Does the project use the Developer Certificate of Origin?
 
-*Do commits include "Signed-Off" trailers? Is the DCO bot enabled on the project? Please provide a link to the commit history where the commits with the "Signed-Off" trailers are shown*
+*Do commits include "Signed-Off" trailers? Is the DCO bot enabled on the project? Are contributors informed about this in your CONTRIBUTING.md? Please provide a link to the commit history where the commits with the "Signed-Off" trailers are shown, as well as your CONTRIBUTING.md where the DCO requirement is mentioned.*
 
 
 


### PR DESCRIPTION
Fixes #155 

Adds a guide on REUSE adoption. Also extends the incubation document and questionnaire accordingly.

Also adds something on the DCO as proposed in the issue.