### PR TITLE
Add license/copyright info to all project template files

### DIFF
--- a/project-templates/CODE_OF_CONDUCT.md
+++ b/project-templates/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2014 Coraline Ada Ehmke
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/project-templates/CONTRIBUTING.md
+++ b/project-templates/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 OpenRail Association AISBL
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Contributing
 
 *The links to the license files need to be checked when adding the file to a repository. The license must be a license approved by the [Open Source Initiative (OSI)] as open source license.*

--- a/project-templates/GOVERNANCE.md
+++ b/project-templates/GOVERNANCE.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 GitHub, Inc.
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Governance Policy
 
 This document provides the governance policy for the Project. Maintainers agree to this policy and to abide by all Project policies, including the [code of conduct](./CODE_OF_CONDUCT.md) by adding their name to the [`MAINTAINERS.md` file](./MAINTAINERS.md).

--- a/project-templates/MAINTAINERS.md
+++ b/project-templates/MAINTAINERS.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 OpenRail Association AISBL
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Maintainers
 
 This document lists the Maintainers of the Project. Maintainers may be added once approved by the existing maintainers as described in the [Governance document](./GOVERNANCE.md). By adding your name to this list you are agreeing to abide by the Project governance documents and to abide by all of the Organization's policies, including the [code of conduct](./CODE_OF_CONDUCT.md). If you are participating because of your affiliation with another organization (designated below), you represent that you have the authority to bind that organization to these policies.

--- a/project-templates/README.md
+++ b/project-templates/README.md
@@ -1,1 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2025 OpenRail Association AISBL
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 This directory contains documents which can be used as templates for projects. It defines the standard files which should be present in every OpenRail Association repository.


### PR DESCRIPTION
Especially when targeting REUSE compliance from the start, it's useful to have this information for these partly external documents.