### PR TITLE
Broken links fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The Technical Committee meets once per week. The agenda for each meeting is prep
 
 ## Projects
 
-Projects can join the OpenRail Association by using the [incubation process](/docs/incubation/process/index.md). Projects are supposed to adhere to certain standards to foster high quality projects which are useful to the sector. The barrier of entry is meant to be low, though. We want to provide an environment where projects can grow within the OpenRail Association. We maintain a set of [project templates](project-templates/) which provides a baseline for projects joining the OpenRail Association in terms of governance according to open principles.
+Projects can join the OpenRail Association by using the [incubation process](/docs/incubation/process/index.md). Projects are supposed to adhere to certain standards to foster high quality projects which are useful to the sector. The barrier of entry is meant to be low, though. We want to provide an environment where projects can grow within the OpenRail Association. 
+We maintain a set of [project templates](project-templates/) which provides a baseline for projects joining the OpenRail Association in terms of governance according to open principles.
 
 See the [official list of projects](docs/joining/projects.md) for which projects are already part of the OpenRail Association.
 


### PR DESCRIPTION
### Fixes broken links

I just got that this repo documentation has many broken links. 

### No clear whether this is ok or not 
We have other issue not resolved by this PR > https://github.com/OpenRailAssociation/technical-committee/blob/c882f05c644e12e9b6337abccc0756831d48d10e/docs/incubation/process/index.md :
- ["OpenRail (Onboarded)"]({{< relref "badges#incubation-stage-1" >}})
- [project handbook]({{< relref "reuse" >}})
- [project handbook]({{< relref "security" >}})
- ["OpenRail (Qualified)"]({{< relref "badges#incubation-stage-2" >}})
- ["OpenRail (Adopted)"]({{< relref "badges#incubation-stage-3" >}})

 
