### PR TITLE
feat: extend best practices, set baseline for administrative projects

### DIFF
--- a/docs/infrastructure/administrative-projects.md
+++ b/docs/infrastructure/administrative-projects.md
@@ -1,0 +1,72 @@
+---
+title: Administrative Projects
+weight: 500
+---
+
+# Administrative Projects and their requirements
+
+This document describes the baseline setup for [Administrative projects of the OpenRail Association]({{< relref "projects/#administrative-projects" >}}). Administrative projects are internal tools and configurations that support the OpenRail Association's operations. They are not incubated projects but still follow high standards.
+
+[purl-tools](https://github.com/OpenRailAssociation/purl-tools) is a good reference implementation that applies all practices described below.
+
+## Repository Settings {#repository-settings}
+
+Configure the repository with these settings:
+
+- **Require pull request reviews**: At least 1 approval before merging (for repos with multiple maintainers)
+
+### GitHub Actions Permissions {#actions-permissions}
+
+Under Settings → Actions → General:
+
+- Set "Fork pull request workflows from outside collaborators" to **Require approval for all outside collaborators**
+- Set "Workflow permissions" to **Read repository contents and packages permissions** (least privilege)
+
+## Badge and Listing {#badge-and-listing}
+
+All administrative projects must display the OpenRail Administrative badge in their `README.md`:
+
+```markdown
+[![OpenRail Administrative Project](https://openrailassociation.org/badges/openrail-project-admin.svg)](https://link.openrailassociation.org/admin-projects)
+```
+
+They must also be listed in the [OpenRail Projects overview]({{< relref "projects/#administrative-projects" >}}) under the "Administrative Projects" section.
+
+## Python Projects {#python}
+
+For Python-based projects, we strongly recommend [uv](https://docs.astral.sh/uv/) as the package manager and build tool, [ruff](https://docs.astral.sh/ruff/) for linting and formatting, and [ty](https://docs.astral.sh/ty/) for type checking. See [purl-tools](https://github.com/OpenRailAssociation/purl-tools) for a working example of `pyproject.toml` and the CI test workflow.
+
+The CI test workflow must run at minimum:
+
+- Linting and format checking (`ruff`)
+- Type checking (`ty`)
+- Functional tests on all supported Python versions (if applicable)
+- [REUSE]({{< relref "reuse" >}}) compliance check
+
+## Security Practices {#security}
+
+Administrative projects follow the [security best practices]({{< relref "security" >}}), which includes the following mandatory items:
+
+- **Dependency management**: Use [Renovate](https://github.com/OpenRailAssociation/renovate-config) extending the shared OpenRail configuration for automated dependency updates and pinned action digests
+- **CI workflow security**: Run [zizmor]({{< relref "security#ci-workflow-security" >}}) to detect security issues in GitHub Actions workflows
+- **Vulnerability monitoring**: Run a weekly check of the latest release against vulnerability databases (for projects that publish releases)
+- **Security policy**: Provide a `SECURITY.md` as described in the [security practices]({{< relref "security#security-policy" >}})
+
+## Releases {#releases}
+
+Administrative projects automate their releases using [release-please](https://github.com/googleapis/release-please) and [Conventional Commits](https://www.conventionalcommits.org/). Since squash merging is enforced, the PR title serves as the commit message and must follow the Conventional Commits format. See [release practices]({{< relref "releases" >}}) for details and [purl-tools](https://github.com/OpenRailAssociation/purl-tools) for a working example.
+
+## Licensing {#licensing}
+
+All administrative projects must be [REUSE]({{< relref "reuse" >}}) compliant.
+
+## Summary Checklist
+
+When creating a new administrative project:
+
+- [ ] [Repository settings](#repository-settings): squash-only merging, auto-delete branches, Actions security permissions
+- [ ] [Badge and listing](#badge-and-listing) in `README.md` and projects overview
+- [ ] [Python project setup](#python): `pyproject.toml` with uv, ruff, ty; CI test workflow
+- [ ] [Security practices](#security): Renovate, zizmor, vulnerability monitoring, `SECURITY.md`
+- [ ] [Automated releases](#releases) with release-please
+- [ ] [REUSE-compliant licensing/copyright information](#licensing)

--- a/docs/infrastructure/administrative-projects.md
+++ b/docs/infrastructure/administrative-projects.md
@@ -52,9 +52,13 @@ Administrative projects follow the [security best practices]({{< relref "securit
 - **Vulnerability monitoring**: Run a weekly check of the latest release against vulnerability databases (for projects that publish releases)
 - **Security policy**: Provide a `SECURITY.md` as described in the [security practices]({{< relref "security#security-policy" >}})
 
+Depending on the type of the project, certain practices may be relaxed. Check the linked security practices document for indicators.
+
 ## Releases {#releases}
 
 Administrative projects automate their releases using [release-please](https://github.com/googleapis/release-please) and [Conventional Commits](https://www.conventionalcommits.org/). Since squash merging is enforced, the PR title serves as the commit message and must follow the Conventional Commits format. See [release practices]({{< relref "releases" >}}) for details and [purl-tools](https://github.com/OpenRailAssociation/purl-tools) for a working example.
+
+Depending on the project, this requirement can be relaxed. Check the linked release practices document for indicators.
 
 ## Licensing {#licensing}
 

--- a/docs/practices/_index.md
+++ b/docs/practices/_index.md
@@ -10,5 +10,6 @@ We generally orient ourselves at general good practices from the Open Source com
 
 * [DCO]({{< relref dco >}})
 * [publiccode.yml]({{< relref publiccode-yml >}})
+* [Automated Releases]({{< relref releases >}})
 * [REUSE]({{< relref reuse >}})
 * [Security]({{< relref security >}})

--- a/docs/practices/releases.md
+++ b/docs/practices/releases.md
@@ -1,0 +1,49 @@
+---
+title: Automated Releases
+weight: 350
+---
+
+# Automated Release Management
+
+It's a best practice for Open Source projects to automate their release process to reduce manual effort and maintain consistent, traceable changelogs. This relies on two complementary practices: a structured commit convention and a release automation tool.
+
+## Conventional Commits
+
+All commits to the default branch must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+```
+type(optional-scope): description
+```
+
+Common types: `feat`, `fix`, `docs`, `ci`, `chore`, `refactor`, `test`, `build`, `perf`.
+
+A `feat` commit triggers a minor version bump, a `fix` commit triggers a patch bump, and a `BREAKING CHANGE` footer triggers a major bump.
+
+In addition, it's best practice to squash-merge pull requests to keep the commit history clean and ensure that the PR title serves as the commit message, which must also follow the Conventional Commits format.
+
+## release-please
+
+[release-please](https://github.com/googleapis/release-please) automates the release process by analysing the commit history. When commits following the Conventional Commits convention are merged to the default branch, release-please creates or updates a release pull request that bumps the version and updates the changelog. Merging that PR triggers the actual release (e.g. creating a Git tag, creating a GitHub release, and publishing to a package repository, if activated).
+
+See [purl-tools](https://github.com/OpenRailAssociation/purl-tools) for a working example, including its `release-please-config.json`, `.release-please-manifest.json`, and release workflow `.github/workflows/release-please.yaml`.
+
+For OpenRail projects, you may use the shared GitHub App (`openrail-releaser`) for authentication, so that the release PR can itself trigger CI workflows. In order to activate this (and make use of the two necessary secrets), an owner of the GitHub organization needs to configure the app and add the new repository to the section "Repository access", as the app is only available for selected repositories.
+
+### Ensuring Conventional Commits for release-please
+
+For release-please to work properly, commit should follow the Conventional Commits format, and pull requests should be squash-merged while ensuring that the PR title (or at least the squash commit) also follows Conventional Commits format. If these requirements are not met, release-please may not be able to correctly determine the next version number or generate a meaningful changelog.
+
+To avoid errors, you may configure the repository:
+
+- **Squash merging only**: Disable "Allow merge commits" and "Allow rebase merging"
+- **Auto-delete branches**: Enable "Automatically delete head branches"
+
+## Publishing to package registries
+
+Many OpenRail projects are Python-based and publish their releases to [PyPI](https://pypi.org/). A good combination with `release-please` is the use of an automatic release workflow that is triggered when a new release is created, which uses OIDC-based authentication to publish the new release and generates signed, digital attestations. This also prevents the need for storing long-lived secrets in GitHub and allows to publish releases without manual intervention.
+
+You may see the workflow configuration in the [purl-tools repository](https://github.com/OpenRailAssociation/purl-tools/blob/main/.github/workflows/publish.yaml) as an example.
+
+In order to make this work, two things are necessary:
+1. You need to create a GitHub environment for teh repository, in the example called `pypi`.
+1. At pypi.org, you need to edit the Publishing settings of the package, and add a new publisher via GitHub. In the input field, you provide information about the repository and the publishing workflow.

--- a/docs/practices/releases.md
+++ b/docs/practices/releases.md
@@ -45,5 +45,5 @@ Many OpenRail projects are Python-based and publish their releases to [PyPI](htt
 You may see the workflow configuration in the [purl-tools repository](https://github.com/OpenRailAssociation/purl-tools/blob/main/.github/workflows/publish.yaml) as an example.
 
 In order to make this work, two things are necessary:
-1. You need to create a GitHub environment for teh repository, in the example called `pypi`.
+1. You need to create a GitHub environment for the repository, in the example called `pypi`.
 1. At pypi.org, you need to edit the Publishing settings of the package, and add a new publisher via GitHub. In the input field, you provide information about the repository and the publishing workflow.

--- a/docs/practices/releases.md
+++ b/docs/practices/releases.md
@@ -7,6 +7,19 @@ weight: 350
 
 It's a best practice for Open Source projects to automate their release process to reduce manual effort and maintain consistent, traceable changelogs. This relies on two complementary practices: a structured commit convention and a release automation tool.
 
+## When automated releases are expected
+
+Automated releases make sense if the project publishes release artifacts beyond the Git repository itself, for example:
+
+- package registry uploads (for example PyPI)
+- GitHub Releases with build artifacts
+- GitHub Marketplace actions
+- container images
+
+In these cases, users consume a packaged output, so reproducible and auditable release creation should be automated.
+
+If a repository is only consumed directly from Git (for example documentation or internal one-off tooling with no published artifacts), release automation can be optional.
+
 ## Conventional Commits
 
 All commits to the default branch must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:

--- a/docs/practices/releases.md
+++ b/docs/practices/releases.md
@@ -21,9 +21,13 @@ A `feat` commit triggers a minor version bump, a `fix` commit triggers a patch b
 
 In addition, it's best practice to squash-merge pull requests to keep the commit history clean and ensure that the PR title serves as the commit message, which must also follow the Conventional Commits format.
 
+## Semantic Versioning
+
+OpenRail projects that publish releases should follow [Semantic Versioning](https://semver.org/), which defines a version format of `MAJOR.MINOR.PATCH` and rules for when to increment each part of the version number based on the types of changes introduced.
+
 ## release-please
 
-[release-please](https://github.com/googleapis/release-please) automates the release process by analysing the commit history. When commits following the Conventional Commits convention are merged to the default branch, release-please creates or updates a release pull request that bumps the version and updates the changelog. Merging that PR triggers the actual release (e.g. creating a Git tag, creating a GitHub release, and publishing to a package repository, if activated).
+[release-please](https://github.com/googleapis/release-please) automates the release process by analysing the commit history. When commits following the Conventional Commits convention are merged to the default branch, release-please creates or updates a release pull request that bumps the version (according to [Semantic Versioning](https://semver.org/)) and updates the changelog. Merging that PR triggers the actual release (e.g. creating a Git tag, creating a GitHub release, and publishing to a package repository, if activated).
 
 See [purl-tools](https://github.com/OpenRailAssociation/purl-tools) for a working example, including its `release-please-config.json`, `.release-please-manifest.json`, and release workflow `.github/workflows/release-please.yaml`.
 

--- a/docs/practices/security.md
+++ b/docs/practices/security.md
@@ -22,6 +22,18 @@ To properly manage dependencies and potential risks, OpenRail projects should:
 
 There are numerous technical solutions that assist maintainers with these steps, e.g. [GitHub's Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) or [Renovate](https://github.com/renovatebot/renovate). OpenRail doesn't mandate a specific solution but recommends to choose a popular, well-supported one.
 
+### When automated dependency updates are expected
+
+Automated dependency updates make sense if any of the following apply, with descending priority:
+
+- the project publishes release artifacts and is still maintained
+- the project is actively developed and has runtime, build, or CI dependencies
+- the project processes untrusted input (for example external pull requests) and therefore benefits from faster security patch adoption
+
+Dependency update automation can be relaxed for one-off or archived projects that are no longer maintained, as long as this status is clearly documented in `README.md`.
+
+To avoid noisy update traffic for projects with less attack surface, it might make sense to adapt the updater cadence to the project lifecycle (for example monthly schedules).
+
 ### Renovate at OpenRail
 
 For many OpenRail projects, we use Renovate for dependency management. OpenRail maintains a [shared Renovate configuration](https://github.com/OpenRailAssociation/renovate-config) that projects can extend.

--- a/docs/practices/security.md
+++ b/docs/practices/security.md
@@ -22,6 +22,30 @@ To properly manage dependencies and potential risks, OpenRail projects should:
 
 There are numerous technical solutions that assist maintainers with these steps, e.g. [GitHub's Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) or [Renovate](https://github.com/renovatebot/renovate). OpenRail doesn't mandate a specific solution but recommends to choose a popular, well-supported one.
 
+### Renovate at OpenRail
+
+For many OpenRail projects, we use Renovate for dependency management. OpenRail maintains a [shared Renovate configuration](https://github.com/OpenRailAssociation/renovate-config) that projects can extend.
+
+In order to activate Renovate for a project, you first need to add the required Renovate configuration file in your repository. If you would like to use the OpenRail presets, please have a look at the [Usage section of the OpenRail Renovate repository](https://github.com/OpenRailAssociation/renovate-config/#usage).
+
+Afterwards, an owner of the GitHub organization needs to configure the app and add the new repository to the section "Repository access", as the app is only available for selected repositories. A few minutes later, the Renovate App will start with opening a Dependency Dashboard and - if applicable - the first PRs for outdated dependencies.
+
+## Vulnerability monitoring of releases
+
+Vulnerability databases are continuously updated, so a dependency that was safe at release time may later be found to be vulnerable. For projects that publish releases, it is important to also monitor the released artifacts for newly discovered vulnerabilities — not just the current development state.
+
+An automated periodic check (e.g. weekly) against vulnerability databases such as [OSV](https://osv.dev/) helps ensure that users of a published version are alerted in time. Tools like [latest-release-vulnerability-status](https://github.com/mxmehl/latest-release-vulnerability-status) can perform this check in a CI workflow.
+
+You may see the workflow configuration in the [purl-tools repository](https://github.com/OpenRailAssociation/purl-tools/blob/main/.github/workflows/release-vulnerabilities.yaml) as an example.
+
+## CI workflow security
+
+GitHub Actions workflows can themselves introduce security risks through unsafe handling of inputs, overly permissive tokens, unpinned action references, or other patterns that could be exploited in supply chain attacks.
+
+[zizmor](https://github.com/zizmorcore/zizmor) is a static analysis tool that detects these issues in GitHub Actions workflow files. After fixing all found issues, it should be run in CI, ideally on every pull request.
+
+You may see the workflow configuration in the [purl-tools repository](https://github.com/OpenRailAssociation/purl-tools/blob/main/.github/workflows/ci-security.yaml) as an example.
+
 ## OpenSSF Scorecard
 
 The [OpenSSF Scorecard](https://scorecard.dev/) is a method and tool to quickly assess Open Source projects for risky practices. Apart from just vulnerabilities it also reports about best and bad practices such as CI tests, code reviews or excessive token permissions. As with most scorecards, opinions on the items and their scoring may differ, but it provides a good overview.


### PR DESCRIPTION
Fixes #327 

This PR does two things:

* Extending the technical and security best practices
* Creating a list of minimum requirements for administrative projects which shall follow a high standard

This PR does not touch the requirements for the official project stages. This is to be discussed by the TC.
